### PR TITLE
Safe sorting

### DIFF
--- a/src/ListBuilder.php
+++ b/src/ListBuilder.php
@@ -38,7 +38,10 @@ abstract class ListBuilder
      */
     public function configure($parameters)
     {
+        $this->filters = [];
         $this->configureFilters($parameters);
+
+        $this->sortings = [];
         $this->configureSorting($parameters);
     }
 
@@ -95,16 +98,24 @@ abstract class ListBuilder
     }
 
     /**
+     * @param $sorting SortingInterface
+     * @param array $parameters
+     */
+    protected function sortUsing(SortingInterface $sorting, array $parameters)
+    {
+        $sorting->bindValues($parameters);
+        $this->sortings[] = $sorting;
+    }
+
+    /**
      * @param QueryBuilder $queryBuilder
      * @return QueryBuilder
      */
     private function applyFilters(QueryBuilder $queryBuilder)
     {
-        if (!empty($this->filters)) {
-            /* @var $filter FilterInterface */
-            foreach ($this->filters as $filter) {
-                $queryBuilder = $filter->apply($queryBuilder);
-            }
+        /* @var $filter FilterInterface */
+        foreach ($this->filters as $filter) {
+            $queryBuilder = $filter->apply($queryBuilder);
         }
 
         return $queryBuilder;
@@ -116,14 +127,8 @@ abstract class ListBuilder
      */
     private function applySortings(QueryBuilder $queryBuilder)
     {
-        if (is_array($this->sortings)) {
-            foreach ($this->sortings as $field => $direction) {
-                if ($direction instanceof SortingInterface) {
-                    $direction->apply($queryBuilder);
-                } else {
-                    $queryBuilder->addOrderBy($field, $direction);
-                }
-            }
+        foreach ($this->sortings as $sorting) {
+            $sorting->apply($queryBuilder);
         }
 
         return $queryBuilder;

--- a/src/Sorting/ByColumn.php
+++ b/src/Sorting/ByColumn.php
@@ -30,8 +30,7 @@ class ByColumn implements SortingInterface
     }
 
     /**
-     * @param mixed $values
-     * @return void
+     * @param array $values
      */
     public function bindValues($values)
     {
@@ -48,7 +47,6 @@ class ByColumn implements SortingInterface
             $this->sortColumn = $this->columnName;
             $this->sortDirection = $this->defaultDirection;
         }
-
     }
 
     /**

--- a/src/Sorting/ByColumn.php
+++ b/src/Sorting/ByColumn.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Ifedko\DoctrineDbalPagination\Sorting;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Ifedko\DoctrineDbalPagination\SortingInterface;
+
+class ByColumn implements SortingInterface
+{
+    const SORT_ASC = 'ASC';
+    const SORT_DESC = 'DESC';
+    const PARAM_NAME_SORT_BY = 'sortBy';
+    const PARAM_NAME_SORT_ORDER = 'sortOrder';
+
+    private $sortColumn;
+    private $sortDirection;
+    private $columnAlias;
+    private $columnName;
+
+    /**
+     * @var null|string one of self::SORT_*
+     */
+    private $defaultDirection;
+
+    public function __construct($columnAlias, $columnName, $defaultDirection = null)
+    {
+        $this->columnAlias = $columnAlias;
+        $this->columnName = $columnName;
+        $this->defaultDirection = $defaultDirection;
+    }
+
+    /**
+     * @param mixed $values
+     * @return void
+     */
+    public function bindValues($values)
+    {
+        $this->sortColumn = null;
+
+        if (isset($values[self::PARAM_NAME_SORT_BY]) && ($values[self::PARAM_NAME_SORT_BY] === $this->columnAlias)) {
+
+            $this->sortColumn = $this->columnName;
+            $this->sortDirection = isset($values[self::PARAM_NAME_SORT_ORDER]) &&
+                in_array(strtoupper($values[self::PARAM_NAME_SORT_ORDER]), [self::SORT_ASC, self::SORT_DESC], true) ?
+                    strtoupper($values['sortOrder']) : $this->defaultDirection;
+
+        } elseif($this->defaultDirection !== null) {
+            $this->sortColumn = $this->columnName;
+            $this->sortDirection = $this->defaultDirection;
+        }
+
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Query\QueryBuilder $builder
+     * @return \Doctrine\DBAL\Query\QueryBuilder
+     */
+    public function apply(QueryBuilder $builder)
+    {
+        if ($this->sortColumn) {
+            $builder->addOrderBy($this->sortColumn, $this->sortDirection);
+        }
+        return $builder;
+    }
+}

--- a/src/SortingInterface.php
+++ b/src/SortingInterface.php
@@ -8,7 +8,6 @@ interface SortingInterface
 {
     /**
      * @param mixed $values
-     * @return void
      */
     public function bindValues($values);
 

--- a/tests/unit/ListBuilderTest.php
+++ b/tests/unit/ListBuilderTest.php
@@ -3,7 +3,6 @@
 namespace Ifedko\DoctrineDbalPagination\Test;
 
 use Mockery;
-use Ifedko\DoctrineDbalPagination\ListBuilder;
 
 class ListBuilderTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/unit/ListPaginationFactoryTest.php
+++ b/tests/unit/ListPaginationFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Ifedko\DoctrineDbalPagination\Test;
 
+use Ifedko\DoctrineDbalPagination\Sorting\ByColumn;
 use Ifedko\DoctrineDbalPagination\SortingInterface;
 use Mockery;
 use Ifedko\DoctrineDbalPagination\ListPaginationFactory;
@@ -21,17 +22,14 @@ class TestListBuilder extends ListBuilder
      */
     protected function configureSorting($parameters)
     {
-        $sorting = [];
-        $direction = (!empty($parameters['sortOrder'])) ? $parameters['sortOrder'] : 'asc';
-        if (isset($parameters['sortBy']) && strlen($parameters['sortBy']) > 0) {
-            $sorting[$parameters['sortBy']] = $direction;
-        }
-
         if ($this->testSortingModel) {
-            $sorting[] = $this->testSortingModel;
+            $this->sortUsing($this->testSortingModel, $parameters);
         }
 
-        $this->sortings = $sorting;
+        $this->sortUsing(new ByColumn('id', 'user_id'), $parameters);
+        $this->sortUsing(new ByColumn('name', 'name'), $parameters);
+        $this->sortUsing(new ByColumn('from', 'user.created_at'), $parameters);
+        $this->sortUsing(new ByColumn('to', 'user.created_at'), $parameters);
 
         return $this;
     }
@@ -106,9 +104,26 @@ class ListPaginationFactoryTest extends \PHPUnit_Framework_TestCase
         ListPaginationFactory::create($dbConnectionMock, $listBuilderClassName);
     }
 
+    public function testSupportsSorting()
+    {
+        $sortingModel = Mockery::mock(SortingInterface::class);
+        $sortingModel->shouldReceive('bindValues')->andReturnSelf();
+        $sortingModel->shouldReceive('apply')->once();
+
+        $builder = new TestListBuilder(self::createDbConnectionMock());
+        $builder->testSortingModel = $sortingModel;
+
+        $builder->configure([
+            'sortBy' => 'from'
+        ]);
+
+        $this->assertContains('ORDER BY user.created_at ASC', $builder->query()->getSQL());
+    }
+
     public function testSupportsComplexSorting()
     {
         $sortingModel = Mockery::mock(SortingInterface::class);
+        $sortingModel->shouldReceive('bindValues')->andReturnSelf();
         $sortingModel->shouldReceive('apply')->once();
 
         $builder = new TestListBuilder(self::createDbConnectionMock());

--- a/tests/unit/ListPaginationFactoryTest.php
+++ b/tests/unit/ListPaginationFactoryTest.php
@@ -107,7 +107,7 @@ class ListPaginationFactoryTest extends \PHPUnit_Framework_TestCase
     public function testSupportsSorting()
     {
         $sortingModel = Mockery::mock(SortingInterface::class);
-        $sortingModel->shouldReceive('bindValues')->andReturnSelf();
+        $sortingModel->shouldReceive('bindValues');
         $sortingModel->shouldReceive('apply')->once();
 
         $builder = new TestListBuilder(self::createDbConnectionMock());
@@ -123,7 +123,7 @@ class ListPaginationFactoryTest extends \PHPUnit_Framework_TestCase
     public function testSupportsComplexSorting()
     {
         $sortingModel = Mockery::mock(SortingInterface::class);
-        $sortingModel->shouldReceive('bindValues')->andReturnSelf();
+        $sortingModel->shouldReceive('bindValues');
         $sortingModel->shouldReceive('apply')->once();
 
         $builder = new TestListBuilder(self::createDbConnectionMock());

--- a/tests/unit/Sorting/ByColumnTest.php
+++ b/tests/unit/Sorting/ByColumnTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Ifedko\DoctrineDbalPagination\Test\Sorting;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Ifedko\DoctrineDbalPagination\Sorting\ByColumn;
+use Mockery as m;
+
+class ByColumnTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConfiguresSortingInQueryBuilder()
+    {
+        $builder = m::mock(QueryBuilder::class);
+        $builder->shouldReceive('addOrderBy')->with('t.name', 'DESC')->once();
+
+        self::sortingByNameWithParameters(
+            [
+                'sortBy' => 'name',
+                'sortOrder' => 'desc'
+            ]
+        )->apply($builder);
+    }
+
+    public function testSortingCanBeDefinedWithoutTheDirection()
+    {
+        $builder = m::mock(QueryBuilder::class);
+        $builder->shouldReceive('addOrderBy')->with('t.name', null)->once();
+
+
+        self::sortingByNameWithParameters(
+            [
+                'sortBy' => 'name',
+            ]
+        )->apply($builder);
+    }
+
+    public function testDoesNoSortingWhenNoParametersWereGiven()
+    {
+        $builder = m::mock(QueryBuilder::class);
+        $builder->shouldReceive('addOrderBy')->never();
+
+        self::sortingByNameWithParameters([])->apply($builder);
+    }
+
+    public function testWillIgnoreUnknownParameters()
+    {
+        $builder = m::mock(QueryBuilder::class);
+        $builder->shouldReceive('addOrderBy')->never();
+
+        self::sortingByNameWithParameters(
+            [
+                'sortBy' => 'table.evil',
+            ]
+        )->apply($builder);
+    }
+
+    public function testPermanentDefaultSortingCanBeGiven()
+    {
+        $builder = m::mock(QueryBuilder::class);
+        $builder->shouldReceive('addOrderBy')->with('t.name', 'DESC')->once();
+
+        self::sortingByNameWithParameters([], 'DESC')->apply($builder);
+    }
+
+    public function testPermanentDefaultSortingIsActiveEvenWhenSortingForOtherColumnIsRequested()
+    {
+        $builder = m::mock(QueryBuilder::class);
+        $builder->shouldReceive('addOrderBy')->with('t.name', 'DESC')->once();
+
+        self::sortingByNameWithParameters(
+            [
+                'sortBy' => 'someOtherColumn',
+                'sortOrder' => 'ASC'
+            ],
+            'DESC'
+        )->apply($builder);
+    }
+
+    public function testPermanentDefaultSortingCanBeOverridden()
+    {
+        $builder = m::mock(QueryBuilder::class);
+        $builder->shouldReceive('addOrderBy')->with('t.name', 'ASC')->once();
+
+        self::sortingByNameWithParameters(
+            [
+                'sortBy' => 'name',
+                'sortOrder' => 'ASC'
+            ],
+            'DESC'
+        )->apply($builder);
+    }
+
+    private static function sortingByNameWithParameters($parameters, $defaultDirection = null)
+    {
+        $sorting = new ByColumn('name', 't.name', $defaultDirection);
+        $sorting->bindValues($parameters);
+
+        return $sorting;
+    }
+}


### PR DESCRIPTION
Don't let GET parameters to go directly into SQL builder. With `Sorting\ByColumn` object we motivate developers not do that.

NOTE! Backwards incompatible change.