### PR TITLE
Fix multiple like filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,17 +168,24 @@ example:
 search: `bla`
 results (3):
 
-bla | first
-bla | second
-bla | final
+c1 | c2
+--- | ---
+**bla** | first |
+**bla** | second |
+**bla** | final |
+
 
 search: `bla fi`
 results (2):
 
-bla | first
-bla | final
+c1 | c2
+--- | ---
+**bla** | **fi**rst
+**bla** | **fi**nal
 
 search: `bla fi -final`
 results (1):
 
-bla | first
+c1 | c2
+--- | ---
+**bla** | **fi**rst

--- a/README.md
+++ b/README.md
@@ -157,3 +157,28 @@ $parameters = [
 * LikeFilter
 * MultipleEqualFilter
 * MultipleLikeFilter
+
+## MultipleLikeFilter
+
+This filter supports complex search queries, like substrings separated by a space. It narrows results
+when more search words is provided. Also negotiation is possible, like '-word'.
+
+example:
+
+search: `bla`
+results (3):
+
+bla | first
+bla | second
+bla | final
+
+search: `bla fi`
+results (2):
+
+bla | first
+bla | final
+
+search: `bla fi -final`
+results (1):
+
+bla | first

--- a/src/ListBuilder.php
+++ b/src/ListBuilder.php
@@ -117,8 +117,8 @@ abstract class ListBuilder
     protected function sortUsing(SortingInterface $sorting, array $parameters)
     {
         $this->sortingParameters = array_merge(
-            $this->sortingParameters,
-            $sorting->bindValues($parameters)
+            $sorting->bindValues($parameters),
+            $this->sortingParameters
         );
         $this->sortings[] = $sorting;
     }

--- a/tests/unit/Filter/Base/MultipleLikeFilterTest.php
+++ b/tests/unit/Filter/Base/MultipleLikeFilterTest.php
@@ -37,7 +37,7 @@ class MultipleLikeFilterTest extends \PHPUnit_Framework_TestCase
         $likeFilter->bindValues('something -like');
         $queryBuilder = $likeFilter->apply($queryBuilder);
         $this->assertContains(
-            "(field LIKE '%something%') AND (field NOT LIKE '%like%')",
+            "(field LIKE '%something%') AND (COALESCE(field, '') NOT LIKE '%like%')",
             $queryBuilder->getSQL()
         );
 
@@ -55,7 +55,7 @@ class MultipleLikeFilterTest extends \PHPUnit_Framework_TestCase
         $likeFilter->bindValues('w1 w2');
         $queryBuilder = $likeFilter->apply($queryBuilder);
         $this->assertContains(
-            "((field1 LIKE '%w1%') AND (field1 LIKE '%w2%')) OR ((field2 LIKE '%w1%') AND (field2 LIKE '%w2%'))",
+            "((field1 LIKE '%w1%') OR (field2 LIKE '%w1%')) AND ((field1 LIKE '%w2%') OR (field2 LIKE '%w2%'))",
             $queryBuilder->getSQL()
         );
 

--- a/tests/unit/ListPaginationFactoryTest.php
+++ b/tests/unit/ListPaginationFactoryTest.php
@@ -28,8 +28,7 @@ class TestListBuilder extends ListBuilder
 
         $this->sortUsing(new ByColumn('id', 'user_id'), $parameters);
         $this->sortUsing(new ByColumn('name', 'name'), $parameters);
-        $this->sortUsing(new ByColumn('from', 'user.created_at'), $parameters);
-        $this->sortUsing(new ByColumn('to', 'user.created_at'), $parameters);
+        $this->sortUsing(new ByColumn('created', 'user.created_at', 'DESC'), $parameters);
 
         return $this;
     }
@@ -109,10 +108,19 @@ class ListPaginationFactoryTest extends \PHPUnit_Framework_TestCase
         $builder = new TestListBuilder(self::createDbConnectionMock());
 
         $builder->configure([
-            'sortBy' => 'from'
+            'sortBy' => 'name'
         ]);
 
-        $this->assertContains('ORDER BY user.created_at ASC', $builder->query()->getSQL());
+        $this->assertContains('ORDER BY name ASC', $builder->query()->getSQL());
+    }
+
+    public function testHasDefaultSorting()
+    {
+        $builder = new TestListBuilder(self::createDbConnectionMock());
+
+        $builder->configure([]);
+
+        $this->assertContains('ORDER BY user.created_at DESC', $builder->query()->getSQL());
     }
 
     public function testSupportsComplexSorting()
@@ -133,14 +141,14 @@ class ListPaginationFactoryTest extends \PHPUnit_Framework_TestCase
         $builder = new TestListBuilder(self::createDbConnectionMock());
 
         $builder->configure([
-            'sortBy' => 'from',
+            'sortBy' => 'name',
             'foo' => 'bar',
             'sortOrder' => 'asc'
         ]);
 
         $this->assertEquals(
             [
-                'sortBy' => 'from',
+                'sortBy' => 'name',
                 'sortOrder' => 'ASC'
             ],
             $builder->sortingParameters()


### PR DESCRIPTION
Please review after https://github.com/ifedko/php-doctrine-dbal-pagination/pull/12

This MR makes MultipleLikeFilter to narrow results providing more search words.

example:

search: **bla**
results (2):
* bla | first
* bla | second


search: **bla fir**
results (1):
* bla | first

