### PR TITLE
Possibility to configure filter to make match from the start of the column

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: php
 
 php:
   - "5.6"
+  - "7.0"
+  - "7.1"
+  - "7.2"
 
 branches:
   only:

--- a/tests/unit/Filter/Base/MultipleLikeFilterTest.php
+++ b/tests/unit/Filter/Base/MultipleLikeFilterTest.php
@@ -10,100 +10,74 @@ class MultipleLikeFilterTest extends \PHPUnit_Framework_TestCase
 {
     public function testApplyWithSingleColumnReturnQueryBuilderSuccess()
     {
-        $queryBuilder = new QueryBuilder(DriverManager::getConnection([
-            'driver' => 'pdo_sqlite',
-            'path' => ':memory:'
-        ]));
-
         $likeFilter = new MultipleLikeFilter('field');
         $likeFilter->bindValues('something like');
-        $queryBuilder = $likeFilter->apply($queryBuilder);
+        $queryBuilder = $likeFilter->apply(self::queryBuilder());
+
+        $this->assertInstanceOf('Doctrine\DBAL\Query\QueryBuilder', $queryBuilder);
         $this->assertContains(
             "(field LIKE '%something%') AND (field LIKE '%like%')",
             $queryBuilder->getSQL()
         );
-
-        $this->assertInstanceOf('Doctrine\DBAL\Query\QueryBuilder', $queryBuilder);
     }
 
     public function testApplyNotContainsWordWithSingleColumnReturnQueryBuilderSuccess()
     {
-        $queryBuilder = new QueryBuilder(DriverManager::getConnection([
-            'driver' => 'pdo_sqlite',
-            'path' => ':memory:'
-        ]));
-
         $likeFilter = new MultipleLikeFilter('field');
         $likeFilter->bindValues('something -like');
-        $queryBuilder = $likeFilter->apply($queryBuilder);
+        $queryBuilder = $likeFilter->apply(self::queryBuilder());
         $this->assertContains(
             "(field LIKE '%something%') AND (COALESCE(field, '') NOT LIKE '%like%')",
             $queryBuilder->getSQL()
         );
-
-        $this->assertInstanceOf('Doctrine\DBAL\Query\QueryBuilder', $queryBuilder);
     }
 
     public function testApplyWithArrayOfColumnsReturnQueryBuilderSuccess()
     {
-        $queryBuilder = new QueryBuilder(DriverManager::getConnection([
-            'driver' => 'pdo_sqlite',
-            'path' => ':memory:'
-        ]));
-
         $likeFilter = new MultipleLikeFilter(['field1', 'field2']);
         $likeFilter->bindValues('w1 w2');
-        $queryBuilder = $likeFilter->apply($queryBuilder);
+        $queryBuilder = $likeFilter->apply(self::queryBuilder());
         $this->assertContains(
             "((field1 LIKE '%w1%') OR (field2 LIKE '%w1%')) AND ((field1 LIKE '%w2%') OR (field2 LIKE '%w2%'))",
             $queryBuilder->getSQL()
         );
-
-        $this->assertInstanceOf('Doctrine\DBAL\Query\QueryBuilder', $queryBuilder);
     }
 
     public function testAcceptsOperatorOption()
     {
-        $queryBuilder = new QueryBuilder(DriverManager::getConnection([
-            'driver' => 'pdo_sqlite',
-            'path' => ':memory:'
-        ]));
-
         $likeFilter = new MultipleLikeFilter('field', ['operator' => 'ILIKE']);
         $likeFilter->bindValues('something like');
-        $queryBuilder = $likeFilter->apply($queryBuilder);
+        $queryBuilder = $likeFilter->apply(self::queryBuilder());
         $this->assertContains(
             "(field ILIKE '%something%') AND (field ILIKE '%like%')",
             $queryBuilder->getSQL()
         );
-
-        $this->assertInstanceOf('Doctrine\DBAL\Query\QueryBuilder', $queryBuilder);
     }
 
     public function testAcceptsMatchFromStartOption()
     {
-        $queryBuilder = new QueryBuilder(DriverManager::getConnection([
-            'driver' => 'pdo_sqlite',
-            'path' => ':memory:'
-        ]));
-
         $likeFilter = new MultipleLikeFilter(
             ['name', 'email'],
             ['operator' => 'ILIKE', 'matchFromStart' => ['name']]
         );
         $likeFilter->bindValues('something like');
-        $queryBuilder = $likeFilter->apply($queryBuilder);
+        $queryBuilder = $likeFilter->apply(self::queryBuilder());
 
-        $this->assertContains(
-            "(name ILIKE 'something%')",
-            $queryBuilder->getSQL()
-        );
+        $this->assertContains("(name ILIKE 'something%')", $queryBuilder->getSQL());
+        $this->assertContains("(email ILIKE '%something%')", $queryBuilder->getSQL());
 
-        $this->assertContains(
-            "(email ILIKE '%something%')",
-            $queryBuilder->getSQL()
-        );
+    }
 
+    /**
+     * @return QueryBuilder
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    private static function queryBuilder()
+    {
+        return new QueryBuilder(DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'path' => ':memory:'
+        ]));
     }
 
 }

--- a/tests/unit/Filter/Base/MultipleLikeFilterTest.php
+++ b/tests/unit/Filter/Base/MultipleLikeFilterTest.php
@@ -80,4 +80,30 @@ class MultipleLikeFilterTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Doctrine\DBAL\Query\QueryBuilder', $queryBuilder);
     }
 
+    public function testAcceptsMatchFromStartOption()
+    {
+        $queryBuilder = new QueryBuilder(DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'path' => ':memory:'
+        ]));
+
+        $likeFilter = new MultipleLikeFilter(
+            ['name', 'email'],
+            ['operator' => 'ILIKE', 'matchFromStart' => ['name']]
+        );
+        $likeFilter->bindValues('something like');
+        $queryBuilder = $likeFilter->apply($queryBuilder);
+
+        $this->assertContains(
+            "(name ILIKE 'something%')",
+            $queryBuilder->getSQL()
+        );
+
+        $this->assertContains(
+            "(email ILIKE '%something%')",
+            $queryBuilder->getSQL()
+        );
+
+    }
+
 }


### PR DESCRIPTION
For some columns it is needed to match like

`column like 'foo%'`

instead of

`column like '%foo%'`

This PR makes this possible by an option, example:

        $likeFilter = new MultipleLikeFilter(
            ['name', 'ean_code'],
            ['operator' => 'ILIKE', 'matchFromStart' => ['ean_code']]
        );
