### PR TITLE
Fix: supports search by zero symbol

### DIFF
--- a/src/Filter/Base/MultipleLikeFilter.php
+++ b/src/Filter/Base/MultipleLikeFilter.php
@@ -43,7 +43,9 @@ class MultipleLikeFilter implements FilterInterface
     public function bindValues($values)
     {
         $values = explode(' ', $values);
-        $values = array_filter($values);
+        $values = array_filter($values, static function($value){
+            return $value !== null && $value !== false && $value !== '';
+        });
 
         foreach ($values as $word) {
             if ($word[0] == '-') {

--- a/tests/unit/Filter/Base/MultipleLikeFilterTest.php
+++ b/tests/unit/Filter/Base/MultipleLikeFilterTest.php
@@ -68,6 +68,22 @@ class MultipleLikeFilterTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function testSupportsSearchByZeroSymbol()
+    {
+        $likeFilter = new MultipleLikeFilter(
+            ['name'],
+            ['operator' => 'ILIKE']
+        );
+        $likeFilter->bindValues('0');
+
+        $queryBuilder = $likeFilter->apply(self::queryBuilder());
+
+        self::assertContains(
+            "name ILIKE '%0%'",
+            $queryBuilder->getSQL()
+        );
+    }
+
     /**
      * @return QueryBuilder
      * @throws \Doctrine\DBAL\DBALException


### PR DESCRIPTION
Hi, @ifedko! We have faced an error in the query when tried to find something with '0' search term using `MultipleLikeFilter`. Looks like the entire reason is that `array_filter()` just filter such value.

FYI @Magomogo.