### PR TITLE
Reset select part of query for total query builder

### DIFF
--- a/src/ListBuilder.php
+++ b/src/ListBuilder.php
@@ -66,7 +66,10 @@ abstract class ListBuilder
      */
     public function totalQuery()
     {
-        $queryBuilder = $this->baseQuery();
+        $queryBuilder = (clone $this->baseQuery())
+            ->resetQueryPart('select')
+            ->select('1');
+
         $queryBuilder = $this->applyFilters($queryBuilder);
         return $queryBuilder;
     }

--- a/tests/unit/ListBuilderTest.php
+++ b/tests/unit/ListBuilderTest.php
@@ -50,6 +50,13 @@ class ListBuilderTest extends TestCase
             'sortBy' => 'field1',
         ];
         $queryBuilderMock = Mockery::mock('Doctrine\DBAL\Query\QueryBuilder');
+        $queryBuilderMock
+            ->shouldReceive('resetQueryPart')
+            ->andReturn($queryBuilderMock);
+
+        $queryBuilderMock
+            ->shouldReceive('select')
+            ->andReturn($queryBuilderMock);
 
         $listBuilderMock = Mockery::mock('Ifedko\DoctrineDbalPagination\ListBuilder[baseQuery]', [$dbConnection])
             ->makePartial()
@@ -60,6 +67,30 @@ class ListBuilderTest extends TestCase
         $queryBuilder = $listBuilderMock->totalQuery();
 
         $this->assertInstanceOf('Doctrine\DBAL\Query\QueryBuilder', $queryBuilder);
+    }
+
+    public function testTotalQueryResetSelectPart()
+    {
+        $dbConnection = self::createDbConnectionMock();
+        $queryBuilderMock = Mockery::mock('Doctrine\DBAL\Query\QueryBuilder');
+        $queryBuilderMock
+            ->shouldReceive('resetQueryPart')
+            ->with('select')
+            ->andReturn($queryBuilderMock)
+            ->once();
+
+        $queryBuilderMock
+            ->shouldReceive('select')
+            ->with('1')
+            ->andReturn($queryBuilderMock)
+            ->once();
+
+        $listBuilderMock = Mockery::mock('Ifedko\DoctrineDbalPagination\ListBuilder', [$dbConnection])
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $listBuilderMock->shouldReceive('baseQuery')->andReturn($queryBuilderMock);
+
+        $listBuilderMock->totalQuery();
     }
 
     private static function createDbConnectionMock()


### PR DESCRIPTION
**The problem:**

When we have some nested SQL select in select fields (in our case we get some data from other table and aggregate the result to JSON string) in baseQuery(), it can lead to performance problems, because of totalQuery() method use the same query from baseQuery when counting total rows. But actually we don not need to select all fields from base query when calculate totals. 

**Solution:**

With changes in this PR, totalQuery() will reset select fields and use some stub like this `SELECT 1 FROM …..`, because of it’s not needed to select any fields to count the total number of rows.